### PR TITLE
added twitch.tv VoD player support

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,18 +95,24 @@ const iframeElem = $("iframe");
 urlElem.addEventListener('change', (e) => {
   const url = urlElem.value.trim();
   if (url) {
-    iframeElem.src = getYoutubeEmbedUrl(url);
+    iframeElem.src = getVideoEmbedUrl(url);
   }
 });
 
  // This is to make the bookmarklet work.
  if (window.location.search.substr(1) != "") {
-     iframeElem.src = getYoutubeEmbedUrl(decodeURIComponent(window.location.search.substr(1)));
+     iframeElem.src = getVideoEmbedUrl(decodeURIComponent(window.location.search.substr(1)));
  }
 
-function getYoutubeEmbedUrl(url) {
+function getVideoEmbedUrl(url) {
   url = url.replace('http://', 'https://');
-  if (url.indexOf('embed') < 0) {
+  if (url.indexOf('twitch.tv') > 0) {
+    var url2 = ''
+    url2 += 'https://player.twitch.tv/?enableExtensions=true&muted=false&player=popout&video='
+    url2 +=  url.substr(url.lastIndexOf('/') + 1)
+    url = url2
+  }
+  else if (url.indexOf('embed') < 0) {
     const params = getParams(url);
     params.autoplay = 1;
     if (params.v) {


### PR DESCRIPTION
I've added in support for twitch vods to enable users to also cast these and speed them up. Probably not a huge audience but easy enough as it just uses the pop-out player URL as an "embed"-able player. I changed the function name just to be precise but didn't change any of the site wording at all to leave the choice up to you.